### PR TITLE
Synopsis constructor supports plain JS object as argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,8 +145,15 @@ var Synopsis = function (options) {
   this.publishers = {}
   if ((typeof options === 'string') || (Buffer.isBuffer(options))) {
     p = JSON.parse(options)
+  } else if (typeof options === 'object') {
+    p = options
+  }
 
+  if (p && p.options) {
     options = p.options
+  }
+
+  if (p && p.publishers) {
     this.publishers = p.publishers
   }
 


### PR DESCRIPTION
Quick fix so constructor supports a plain old JS object / parsed JSON (it was working for Buffers and Strings containing unparsed JSON) containing the ledger-client options.

fixes #3
